### PR TITLE
Add a hasPermission method to check permission

### DIFF
--- a/SecurityBridgeGrailsPlugin.groovy
+++ b/SecurityBridgeGrailsPlugin.groovy
@@ -24,6 +24,9 @@ class SecurityBridgeGrailsPlugin {
     def authorEmail = "destes@bcap.com"
     def description = 'Defines a standard corss-plugin security bridge implementation for better decoupling of authentication in plugin heavy applications.'
 
+    def developers = [
+        [name: 'Jeremy Michael Crosbie', email: 'jcrosbie@bcap.com']
+    ]
     def documentation   = "http://bertramdev.github.io/grails-security-bridge"
     def license = "APACHE"
     def organization = [name: "Bertram Labs", url: "http://www.bertramlabs.com/"]

--- a/grails-app/services/org/grails/plugin/securitybridge/SharedSecurityService.groovy
+++ b/grails-app/services/org/grails/plugin/securitybridge/SharedSecurityService.groovy
@@ -27,7 +27,7 @@ class SharedSecurityService implements SecurityBridge {
    * Execute the closure with the user and account object based on the passed id
    */
   def withUser(identity, Closure code) {
-      getSecurityBridge(failOnError: true).withUser(identity, code)
+    getSecurityBridge(failOnError: true).withUser(identity, code)
   }
 
 
@@ -87,6 +87,13 @@ class SharedSecurityService implements SecurityBridge {
 	 	securityBridge?.isAuthorized(object, action)
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+  boolean hasPermission(permission, opts=null) {
+    securityBridge?.hasPermission(permission, opts)
+  }
+
   /**
    * Check if the currently logged in user has the specified role
    * @param role
@@ -98,7 +105,7 @@ class SharedSecurityService implements SecurityBridge {
   boolean hasAnyRole(roles) {
     roles = roles instanceof Collection ? roles : [roles]
     roles.any { role ->
-        getSecurityBridge()?.hasRole(role)
+      getSecurityBridge()?.hasRole(role)
     }
   }
 

--- a/src/groovy/org/grails/plugin/securitybridge/AbstractSecurityBridge.groovy
+++ b/src/groovy/org/grails/plugin/securitybridge/AbstractSecurityBridge.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.plugin.securitybridge
+
+abstract class AbstractSecurityBridge implements SecurityBridge {
+
+  /**
+   * {@inheritDoc}
+   * @return null
+   */
+  def getCurrentUser() {
+    null
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return null
+   */
+  def getUserIdentity() {
+    null
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return null
+   */
+  def getCurrentAccount() {
+    null
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return null
+   */
+  def getAccountIdentity() {
+    null
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return null
+   */
+  def getCurrentUserDisplayName() {
+    null
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return false
+   */
+  boolean isLoggedIn() {
+    false
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return false
+   */
+  boolean isAuthorized(object, action) {
+    false
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return false
+   */
+  boolean hasRole(role) {
+    false
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return false
+   */
+  boolean hasPermission(permission, opts=null) {
+    false
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  def storeLocation(request) {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  def withUser(identity, Closure code) {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  Map createLink(String action) {
+  }
+}

--- a/src/groovy/org/grails/plugin/securitybridge/SecurityBridge.groovy
+++ b/src/groovy/org/grails/plugin/securitybridge/SecurityBridge.groovy
@@ -65,6 +65,23 @@ interface SecurityBridge {
 	boolean hasRole(role)
 
 	/**
+	 * Check if the currently logged in user has the specified permission
+	 * in any of his/her assigned roles.
+	 * @param permission the name of the permission to check
+	 * @param opts depending on then permissions model, this can be used to add
+	 * configurability to permission.
+	 */
+	boolean hasPermission(permission, opts)
+
+	/**
+	 * Check if the currently logged in user has the specified permission
+	 * in any of his/her assigned roles.
+	 * @param permission the name of the permission to check
+	 */
+	boolean hasPermission(permission)
+
+
+	/**
 	 * Store the request location for the security service to redirect to upon login success
 	 * @param request The request object
 	 */


### PR DESCRIPTION
For security models where roles are composites of any number of
permissions.  The intent is for this method to check if a given
permission exists in any of the roles assigned to the current user.

A second, optional parameter is also available to be used for
permissions with more fine-grained attributes.  It is intended to be
very specific to the underlying security model.
